### PR TITLE
Adds a default limit for find_all when not specified

### DIFF
--- a/motorengine/queryset.py
+++ b/motorengine/queryset.py
@@ -12,6 +12,7 @@ from motorengine.aggregation.base import Aggregation
 from motorengine.connection import get_connection
 from motorengine.errors import UniqueKeyViolationError
 
+DEFAULT_LIMIT = 1000
 
 class QuerySet(object):
     def __init__(self, klass):
@@ -488,6 +489,8 @@ class QuerySet(object):
 
         if self._limit is not None:
             to_list_arguments['length'] = self._limit
+        else:
+            to_list_arguments['length'] = DEFAULT_LIMIT
 
         cursor = self._get_find_cursor(alias=alias)
 


### PR DESCRIPTION
Starting with https://github.com/eguven/motor/commit/89f9085a05, limit is now a required positional argument for find_all in motor, which is why so many tests are failing on travis.

This is a potentially breaking change, so I'd like some feedback on if this is the right approach (and if so, what a good default would be).
