### PR TITLE
Allow IntField, FloatField and UUIDField to be None

### DIFF
--- a/motorengine/fields/float_field.py
+++ b/motorengine/fields/float_field.py
@@ -32,6 +32,8 @@ class FloatField(BaseField):
         return float(value)
 
     def validate(self, value):
+        if value is None:
+            return True
         try:
             value = float(value)
         except:

--- a/motorengine/fields/int_field.py
+++ b/motorengine/fields/int_field.py
@@ -32,6 +32,8 @@ class IntField(BaseField):
         return int(value)
 
     def validate(self, value):
+        if value is None:
+            return True
         try:
             value = int(value)
         except:

--- a/motorengine/fields/uuid_field.py
+++ b/motorengine/fields/uuid_field.py
@@ -20,6 +20,8 @@ class UUIDField(BaseField):
     '''
 
     def validate(self, value):
+        if value is None:
+            return True
         if isinstance(value, UUID):
             return True
 

--- a/tests/fields/test_float_field.py
+++ b/tests/fields/test_float_field.py
@@ -32,6 +32,12 @@ class TestFloatField(AsyncTestCase):
         expect(field.validate(1.0)).to_be_true()
         expect(field.validate("1.5")).to_be_true()
         expect(field.validate("qwe")).to_be_false()
+        expect(field.validate(None)).to_be_true()
+
+    def test_validate_is_empty(self):
+        field = FloatField()
+
+        expect(field.is_empty(None)).to_be_true()
 
     def test_validate_enforces_min_value(self):
         field = FloatField(min_value=5.4)

--- a/tests/fields/test_int_field.py
+++ b/tests/fields/test_int_field.py
@@ -36,6 +36,12 @@ class TestIntField(AsyncTestCase):
         expect(field.validate(1)).to_be_true()
         expect(field.validate("1")).to_be_true()
         expect(field.validate("qwe")).to_be_false()
+        expect(field.validate(None)).to_be_true()
+
+    def test_is_empty(self):
+        field = IntField()
+
+        expect(field.is_empty(None)).to_be_true()
 
     def test_validate_enforces_min_value(self):
         field = IntField(min_value=5)

--- a/tests/fields/test_uuid_field.py
+++ b/tests/fields/test_uuid_field.py
@@ -21,6 +21,7 @@ class TestUUIDField(AsyncTestCase):
         expect(field.validate("123")).to_be_false()
         expect(field.validate(uuid)).to_be_true()
         expect(field.validate(str(uuid))).to_be_true()
+        expect(field.validate(None)).to_be_true()
 
     def test_is_empty(self):
         field = UUIDField()


### PR DESCRIPTION
Suggested fix for Issue #75 
1. Added a check for None in IntField, UUIDField and FloatField validate methods
2. Added unit tests that check None validity and emptyness
