### PR TITLE
Add serialization support for empty Int and Float fields

### DIFF
--- a/motorengine/fields/float_field.py
+++ b/motorengine/fields/float_field.py
@@ -26,9 +26,13 @@ class FloatField(BaseField):
         self.max_value = max_value
 
     def to_son(self, value):
+        if value is None:
+            return None
         return float(value)
 
     def from_son(self, value):
+        if value is None:
+            return None
         return float(value)
 
     def validate(self, value):

--- a/motorengine/fields/int_field.py
+++ b/motorengine/fields/int_field.py
@@ -26,9 +26,13 @@ class IntField(BaseField):
         self.max_value = max_value
 
     def to_son(self, value):
+        if value is None:
+            return None
         return int(value)
 
     def from_son(self, value):
+        if value is None:
+            return None
         return int(value)
 
     def validate(self, value):

--- a/tests/integration/fields/test_float_field.py
+++ b/tests/integration/fields/test_float_field.py
@@ -22,7 +22,7 @@ class MotorDocument(motorengine.Document):
     number = motorengine.FloatField()
 
 
-class TestIntField(BaseIntegrationTest):
+class TestFloatField(BaseIntegrationTest):
     @gen_test
     def test_can_integrate(self):
         mongo_document = MongoDocument(number=10.5).save()
@@ -40,3 +40,12 @@ class TestIntField(BaseIntegrationTest):
 
         expect(result.id).to_equal(motor_document._id)
         expect(result.number).to_equal(motor_document.number)
+
+    @gen_test
+    def test_empty_field(self):
+        motor_document = yield MotorDocument.objects.create()
+
+        result = yield MotorDocument.objects.get(id=motor_document._id)
+
+        expect(result).not_to_be_null()
+        expect(result.number).to_be_null()

--- a/tests/integration/fields/test_int_field.py
+++ b/tests/integration/fields/test_int_field.py
@@ -40,3 +40,12 @@ class TestIntField(BaseIntegrationTest):
 
         expect(result.id).to_equal(motor_document._id)
         expect(result.number).to_equal(motor_document.number)
+
+    @gen_test
+    def test_empty_field(self):
+        motor_document = yield MotorDocument.objects.create()
+
+        result = yield MotorDocument.objects.get(id=motor_document._id)
+
+        expect(result).not_to_be_null()
+        expect(result.number).to_be_null()

--- a/tests/integration/fields/test_uuid_field.py
+++ b/tests/integration/fields/test_uuid_field.py
@@ -50,3 +50,12 @@ class TestUUIDField(BaseIntegrationTest):
         results = yield MotorDocument.objects.filter(uuid=motor_document.uuid).find_all()
         expect(results).to_length(1)
         expect(results[0]._id).to_equal(motor_document._id)
+
+    @gen_test
+    def test_empty_field(self):
+        motor_document = yield MotorDocument.objects.create()
+
+        result = yield MotorDocument.objects.get(id=motor_document._id)
+
+        expect(result).not_to_be_null()
+        expect(result.uuid).to_be_null()


### PR DESCRIPTION
Additional fix for issue #75 
Allows empty Float and Int fields to be serialized and deserialzed. 
Added unit tests that test empty Int Float and UUID fields.
