### PR TITLE
Boolean fields

### DIFF
--- a/docs/source/modeling.rst
+++ b/docs/source/modeling.rst
@@ -12,6 +12,7 @@ Modeling
 .. py:module:: motorengine.fields.url_field
 .. py:module:: motorengine.fields.email_field
 .. py:module:: motorengine.fields.int_field
+.. py:module:: motorengine.fields.boolean_field
 .. py:module:: motorengine.fields.float_field
 .. py:module:: motorengine.fields.decimal_field
 .. py:module:: motorengine.fields.binary_field
@@ -122,6 +123,8 @@ Available Fields
 .. autoclass:: motorengine.fields.email_field.EmailField
 
 .. autoclass:: motorengine.fields.int_field.IntField
+
+.. autoclass:: motorengine.fields.int_field.BooleanField
 
 .. autoclass:: motorengine.fields.float_field.FloatField
 

--- a/motorengine/fields/boolean_field.py
+++ b/motorengine/fields/boolean_field.py
@@ -5,6 +5,13 @@ from motorengine.fields.base_field import BaseField
 
 
 class BooleanField(BaseField):
+    '''
+    Field responsible for storing boolean values (:py:func:`bool`).
+    Usage:
+    .. testcode:: modeling_fields
+        isActive = BooleanField(required=True)
+    `BooleanField` has no additional arguments available (apart from those in `BaseField`).
+    '''
     def __init__(self, *args, **kw):
         super(BooleanField, self).__init__(*args, **kw)
 


### PR DESCRIPTION
`BooleanField` was not mentioned in the documentation at all. This PR adds some information on BooleanField to the docuemntation as well as adds a docstring for the BooleanField class.