### PR TITLE
Overwritten values with DynamicFields if two versions of the same document-definition exist

### DIFF
--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -57,13 +57,7 @@ class BaseDocument(object):
         for name, value in dic.items():
             field = cls.get_field_by_db_name(name)
             if field:
-                if isinstance(field, DynamicField) and field.name in cls._fields: # There is an defined field in out OM. We dont need the dynfield anymore.
-                    if name in cls._fields: #only delete the dynfield if it was cached.
-                        del cls._fields[name]
-                    if not field.name in dic: # The real is currently not in the query result: apply the dynfield value.
-                        field_values[field.name] = cls._fields[field.name].from_son(value)
-                else:
-                    field_values[field.name] = cls._fields[field.name].from_son(value)
+                field_values[field.name] = cls._fields[field.name].from_son(value)
             else:
                 field_values[name] = value
 
@@ -302,7 +296,7 @@ class BaseDocument(object):
     @classmethod
     def get_field_by_db_name(cls, name):
         for field_name, field in cls._fields.items():
-            if name == field.db_field:
+            if name == field.db_field or name.lstrip("_") == field.db_field:
                 return field
         return None
 

--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -52,11 +52,18 @@ class BaseDocument(object):
 
     @classmethod
     def from_son(cls, dic):
+        from motorengine.fields.dynamic_field import DynamicField
         field_values = {}
         for name, value in dic.items():
             field = cls.get_field_by_db_name(name)
             if field:
-                field_values[field.name] = cls._fields[field.name].from_son(value)
+                if isinstance(field, DynamicField) and field.name in cls._fields: # There is an defined field in out OM. We dont need the dynfield anymore.
+                    if name in cls._fields: #only delete the dynfield if it was cached.
+                        del cls._fields[name]
+                    if not field.name in dic: # The real is currently not in the query result: apply the dynfield value.
+                        field_values[field.name] = cls._fields[field.name].from_son(value)
+                else:
+                    field_values[field.name] = cls._fields[field.name].from_son(value)
             else:
                 field_values[name] = value
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1024,6 +1024,66 @@ class TestDocument(AsyncTestCase):
 
         expect(document_count).to_equal(1)
 
+    def test_dynamic_fields_with_two_version_fields(self):
+        
+        class Version1Document(Document):
+            __collection__ = "TestDynamicFieldDocumentQuery1"
+            old_element = StringField(default="old_string_field")
+            
+        class Version2Document(Document):
+            __collection__ = "TestDynamicFieldDocumentQuery1"
+            old_element = StringField(default="old_string_field")
+            new_element = StringField(default="new_string_field")    
+        
+
+        self.drop_coll(Version1Document.__collection__)
+
+        doc1 = Version1Document()
+        doc1.old_element = "my_old_string_field1"
+        doc1.save(callback=self.stop)
+        doc1 = self.wait()
+        
+        doc2 = Version2Document()
+        doc2.old_element = "my_old_string_field2"
+        doc2.new_element = "my_new_string_field2"
+        doc2.save(callback=self.stop)
+        doc2 = self.wait()
+
+        # Querying with the old Version1.
+        # This effect happens when you have 2 different services using different versions of the document.
+        # When editing the version1 document, no _dynfield value should be added because version2 will
+        # eventually overwrite real values from new_field.
+        Version1Document.objects.get(old_element="my_old_string_field2", callback=self.stop)
+        doc2_with_version1 = self.wait()
+        
+        expect(doc2_with_version1._id).not_to_be_null()
+        expect(doc2_with_version1.old_element).to_equal("my_old_string_field2")
+        expect(doc2_with_version1.new_element).to_equal("my_new_string_field2")
+        
+        Version1Document.objects.get(old_element="my_old_string_field2", callback=self.stop)
+        doc2_with_version1 = self.wait()
+        
+        expect(doc2_with_version1._id).not_to_be_null()
+        expect(doc2_with_version1.old_element).to_equal("my_old_string_field2")
+        expect(doc2_with_version1.new_element).to_equal("my_new_string_field2")
+        
+        # Changing one field and saving it.
+        doc2_with_version1.old_element = "my_old_string_field2_modified"
+        doc2_with_version1.save(callback=self.stop)
+        doc2_with_version1 = self.wait()
+        # The database should contain the dynamic field.
+        # Querying with the new version should not overwrite the data.
+        Version2Document.objects.get(old_element="my_old_string_field2_modified", callback=self.stop)
+        doc2_with_version2 = self.wait()
+        expect(doc2_with_version2._id).not_to_be_null()
+        expect(doc2_with_version2.old_element).to_equal("my_old_string_field2_modified")
+        
+        doc2_with_version2.save(callback=self.stop)
+        doc2_with_version2 = self.wait()
+        
+        # After saving the new version of the document it should stay the way it was designed to be
+        expect(doc2_with_version2.new_element).to_equal("my_new_string_field2")
+
     def test_can_query_by_elem_match(self):
         class ElemMatchDocument(Document):
             items = ListField(IntField())


### PR DESCRIPTION
Hi,

thanks for the lib and all the work!

There is a rare case when two versions of the same document exist and DynamicFields are created and then overwrite values.
This happens when:
You have two services. The newer services adds new fields to the database-definition. When the older version reads the database there might be some unknown fields. For those fields it creates DynamicFields and stores them as DynamicFields. So far so good.
If the newer version reads those entries from the database it does not recognize that those DynamicFields are already defined in the database-definition.
When the values are stored again it simply overwrites the previous values because the name-property of the DynamicField is without an _ and the dict which is sent to mongo is updated twice with the same name. 

My proposal is to check if the name of the DynamicField without an _ is already in the database definition. If so, that field is used.