### PR TITLE
Sparse fields

### DIFF
--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -52,7 +52,6 @@ class BaseDocument(object):
 
     @classmethod
     def from_son(cls, dic):
-        from motorengine.fields.dynamic_field import DynamicField
         field_values = {}
         for name, value in dic.items():
             field = cls.get_field_by_db_name(name)
@@ -68,6 +67,8 @@ class BaseDocument(object):
 
         for name, field in self._fields.items():
             value = self.get_field_value(name)
+            if field.sparse and field.is_empty(value):
+                continue
             data[field.db_field] = field.to_son(value)
 
         return data

--- a/motorengine/fields/base_field.py
+++ b/motorengine/fields/base_field.py
@@ -13,6 +13,7 @@ class BaseField(object):
     * `required` - Indicates that if the field value evaluates to empty (using the `is_empty` method) a validation error is raised
     * `on_save` - A function of the form `lambda doc, creating` that is called right before sending the document to the DB.
     * `unique` - Indicates whether an unique index should be created for this field.
+    * `sparse` - Indicates whether a sparse index should be created for this field. This also will not pass empty values to DB.
 
     To create a new field, four methods can be overwritten:
 
@@ -24,7 +25,7 @@ class BaseField(object):
 
     total_creation_counter = 0
 
-    def __init__(self, db_field=None, default=None, required=False, on_save=None, unique=None):
+    def __init__(self, db_field=None, default=None, required=False, on_save=None, unique=None, sparse=False):
         global creation_counter
         self.creation_counter = BaseField.total_creation_counter
         BaseField.total_creation_counter += 1
@@ -34,6 +35,7 @@ class BaseField(object):
         self.default = default
         self.on_save = on_save
         self.unique = unique
+        self.sparse = sparse
 
     def is_empty(self, value):
         return value is None

--- a/motorengine/queryset.py
+++ b/motorengine/queryset.py
@@ -548,24 +548,25 @@ class QuerySet(object):
 
     @return_future
     def ensure_index(self, callback, alias=None):
-        indexes = []
+        fields_with_index = []
         for field_name, field in self.__klass__._fields.items():
-            if field.unique:
-                indexes.append(field.db_field)
+            if field.unique or field.sparse:
+                fields_with_index.append(field)
 
         created_indexes = []
 
-        for index in indexes:
+        for field in fields_with_index:
             self.coll(alias).ensure_index(
-                index,
-                unique=True,
+                field.db_field,
+                unique=field.unique,
+                sparse=field.sparse,
                 callback=self.handle_ensure_index(
                     callback,
                     created_indexes,
-                    len(indexes)
+                    len(fields_with_index)
                 ),
                 alias=alias
             )
 
-        if not indexes:
+        if not fields_with_index:
             callback(0)


### PR DESCRIPTION
Thanks for the great library!

Sometimes there is a need in field which is unique, but might be empty. So there is sparse index in Mongo DB, but for that index field value should not be a null, but there should not be a field in document.
Now every empty field goes to database.
With this new parameter empty fields won't go to database, so we will be able to use unique and sparse index for such field.

The only thing I'm not sure about - is checking for emptiness. Is 'is_empty' a good way? It is true for empty lists, but empty list is different from absence of list.