### PR TITLE
update pymongo&motor versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,9 @@ MotorEngine is a port of the amazing MongoEngine Mapper. Instead of using pymong
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'pymongo==2.7',
+        'pymongo >= 2.7, <= 2.8',
         'tornado',
-        'motor==0.2',
+        'motor >= 0.2, <= 0.4.1',
         'six',
         'easydict'
     ],


### PR DESCRIPTION
I have motorengine in production with motor 0.4.1 & pymongo 2.8. Everything seems fine
According to changelogs ([motor](https://motor.readthedocs.org/en/stable/changelog.html#motor-0-4-1) and [pymongo](http://api.mongodb.org/python/current/changelog.html#changes-in-version-2-8)) there are no significant changes that might broke something
