### PR TITLE
check is None instead of is_empty for sparse fields

### DIFF
--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -67,7 +67,7 @@ class BaseDocument(object):
 
         for name, field in self._fields.items():
             value = self.get_field_value(name)
-            if field.sparse and field.is_empty(value):
+            if field.sparse and value is None:
                 continue
             data[field.db_field] = field.to_son(value)
 


### PR DESCRIPTION
because None is the proper way to show absence of value.

following discussion in #106
