### PR TITLE
Fixed bug with default values are not properly set   

### DIFF
--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -20,12 +20,12 @@ class BaseDocument(object):
 
         for key, field in self._fields.items():
             if callable(field.default):
-                self._values[field.db_field] = field.default()
+                self._values[field.name] = field.default()
             else:
-                self._values[field.db_field] = field.default
+                self._values[field.name] = field.default
 
         for key, value in kw.items():
-            if key not in self._db_field_map:
+            if key not in self._fields:
                 self._fields[key] = DynamicField(db_field="_%s" % key.lstrip('_'))
             self._values[key] = value
 


### PR DESCRIPTION
Fixed bug with default values are not properly set when a db_field is not equal to a name of the field.