### PR TITLE
Add projection methods only(), exclude() and other to QuerySet

### DIFF
--- a/docs/source/getting-and-querying.rst
+++ b/docs/source/getting-and-querying.rst
@@ -124,3 +124,22 @@ In order to use raw queries, just pass the same object you would use in mongodb:
 
         io_loop.add_timeout(1, create_user)
         io_loop.start()
+
+Retrieving a subset of fields
+-----------------------------
+
+Sometimes a subset of fields on a Document is required, and for efficiency only these should be retrieved from the database. There are some methods that could be used to specify which fields to retrieve. Note that if fields that are not downloaded are accessed, their default value (or None if no default value is provided) will be given.
+
+Projections for reference fields (and a list of reference fields) can be specified too in the same way as for embedded fields. They are applied immediately if `lazy` is `False` or will be applied later after `.load_reference()` will be called otherwise.
+
+.. note:: You can use `BlogPost.title` notation instead of string value 'title' only for the first level fields. So `BlogPost.author.name` will not work, use string 'author.name' instead. Also `_id` field should be always specified as string '_id'.
+
+.. note:: It is not possible to save document with projection specified during retrieving. It will raise exception `motorengine.errors.PartlyLoadedDocumentError` as you would try that.
+
+.. automethod:: motorengine.queryset.QuerySet.only
+
+.. automethod:: motorengine.queryset.QuerySet.exclude
+
+.. automethod:: motorengine.queryset.QuerySet.all_fields
+
+.. automethod:: motorengine.queryset.QuerySet.fields

--- a/docs/source/modeling.rst
+++ b/docs/source/modeling.rst
@@ -124,7 +124,7 @@ Available Fields
 
 .. autoclass:: motorengine.fields.int_field.IntField
 
-.. autoclass:: motorengine.fields.int_field.BooleanField
+.. autoclass:: motorengine.fields.boolean_field.BooleanField
 
 .. autoclass:: motorengine.fields.float_field.FloatField
 

--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -20,12 +20,12 @@ class BaseDocument(object):
 
         for key, field in self._fields.items():
             if callable(field.default):
-                self._values[field.db_field] = field.default()
+                self._values[field.name] = field.default()
             else:
-                self._values[field.db_field] = field.default
+                self._values[field.name] = field.default
 
         for key, value in kw.items():
-            if key not in self._db_field_map:
+            if key not in self._fields:
                 self._fields[key] = DynamicField(db_field="_%s" % key.lstrip('_'))
             self._values[key] = value
 

--- a/motorengine/errors.py
+++ b/motorengine/errors.py
@@ -12,6 +12,10 @@ class LoadReferencesRequiredError(RuntimeError):
     pass
 
 
+class PartlyLoadedDocumentError(ValueError):
+    pass
+
+
 # E11000 duplicate key error index: test.UniqueFieldDocument.$name_1  dup key: { : "test" }
 PYMONGO_ERROR_REGEX = re.compile(r"(?P<error_code>.+?)\s(?P<error_type>.+?):\s*(?P<index_name>.+?)\s+(?P<error>.+?)")
 

--- a/motorengine/fields/boolean_field.py
+++ b/motorengine/fields/boolean_field.py
@@ -7,9 +7,13 @@ from motorengine.fields.base_field import BaseField
 class BooleanField(BaseField):
     '''
     Field responsible for storing boolean values (:py:func:`bool`).
+
     Usage:
+
     .. testcode:: modeling_fields
+
         isActive = BooleanField(required=True)
+
     `BooleanField` has no additional arguments available (apart from those in `BaseField`).
     '''
     def __init__(self, *args, **kw):

--- a/motorengine/query/is_null.py
+++ b/motorengine/query/is_null.py
@@ -39,7 +39,8 @@ class IsNullQueryOperator(QueryOperator):
         assert 'email' in query_result
         assert '$ne' in query_result['email']
         assert '$exists' in query_result['email']
-r   '''
+
+    '''
 
     def to_query(self, field_name, value):
         if value:

--- a/motorengine/query_builder/field_list.py
+++ b/motorengine/query_builder/field_list.py
@@ -1,0 +1,112 @@
+from motorengine.query_builder.transform import transform_field_list_query
+
+__all__ = ('QueryFieldList',)
+
+
+class QueryFieldList(object):
+    '''Object that handles combinations of .only() and .exclude() calls'''
+    ONLY = 1
+    EXCLUDE = 0
+
+    def __init__(
+        self, fields=None, value=ONLY, always_include=None, _only_called=False
+    ):
+        '''
+        The QueryFieldList builder
+
+        :param fields: A list of fields used in `.only()` or `.exclude()`
+        :param value: How to handle the fields; either `ONLY` or `EXCLUDE`
+        :param always_include: Any fields to always_include eg `_cls`
+        :param _only_called: Has `.only()` been called?  If so its a set of
+            fields otherwise it performs a union.
+        '''
+        self.value = value
+        self.fields = set(fields or [])
+        self.always_include = set(always_include or [])
+        self._id = None
+        self._only_called = _only_called
+        self.slice = {}
+
+    def __add__(self, f):
+        if isinstance(f.value, dict):
+            for field in f.fields:
+                self.slice[field] = f.value
+            if not self.fields:
+                self.fields = f.fields
+        elif not self.fields:
+            self.fields = f.fields
+            self.value = f.value
+            self.slice = {}
+        elif self.value is self.ONLY and f.value is self.ONLY:
+            self._clean_slice()
+            if self._only_called:
+                self.fields = self.fields.union(f.fields)
+            else:
+                self.fields = f.fields
+        elif self.value is self.EXCLUDE and f.value is self.EXCLUDE:
+            self.fields = self.fields.union(f.fields)
+            self._clean_slice()
+        elif self.value is self.ONLY and f.value is self.EXCLUDE:
+            self.fields -= f.fields
+            self._clean_slice()
+        elif self.value is self.EXCLUDE and f.value is self.ONLY:
+            self.value = self.ONLY
+            self.fields = f.fields - self.fields
+            self._clean_slice()
+
+        # _id should be saved separately to avoid situation such as
+        # exclude('_id').only('other') so the previous code of this method
+        # remove _id from self.fields (its a normal behavior for any field
+        # except for _id because _id field cannot be removed with only)
+        if '_id' in f.fields:
+            self._id = f.value
+
+        if self.always_include:
+            if self.value is self.ONLY and self.fields:
+                if sorted(self.slice.keys()) != sorted(self.fields):
+                    self.fields = self.fields.union(self.always_include)
+            else:
+                # if this is exclude - remove from fields values from
+                # always included fields
+                self.fields -= self.always_include
+
+        if getattr(f, '_only_called', False):
+            self._only_called = True
+        return self
+
+    # python2
+    def __nonzero__(self):
+        return bool(self.fields)
+
+    # python3
+    def __bool__(self):
+        return bool(self.fields)
+
+    def as_dict(self):
+        field_list = dict((field, self.value) for field in self.fields)
+
+        if self.slice:
+            field_list.update(self.slice)
+
+        if self._id is not None:
+            field_list['_id'] = self._id
+
+        return field_list
+
+    def to_query(self, document):
+        ''' Transform to query using db names for fields
+
+        :param document - class of the document
+        '''
+        return transform_field_list_query(document, self.as_dict())
+
+    def reset(self):
+        self.fields = set([])
+        self.slice = {}
+        self.value = self.ONLY
+        self._id = None
+
+    def _clean_slice(self):
+        if self.slice:
+            for field in set(self.slice.keys()) - self.fields:
+                del self.slice[field]

--- a/motorengine/query_builder/transform.py
+++ b/motorengine/query_builder/transform.py
@@ -105,3 +105,19 @@ def validate_fields(document, query):
             raise ValueError(
                 "Invalid filter '%s': Invalid operator (if this is a sub-property, "
                 "then it must be used in embedded document fields)." % key)
+
+
+def transform_field_list_query(document, query_field_list):
+    if not query_field_list:
+        return None
+
+    fields = {}
+    for key in query_field_list.keys():
+        if key == '_id':
+            fields[key] = query_field_list[key]
+        else:
+            fields_chain = document.get_fields(key)
+            field_db_name = '.'.join([field.db_field for field in fields_chain])
+            fields[field_db_name] = query_field_list[key]
+
+    return fields

--- a/tests/test_query_field_list.py
+++ b/tests/test_query_field_list.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from preggy import expect
+# from tornado.testing import gen_test
+
+from motorengine import (
+    Document, StringField, EmbeddedDocumentField, ListField, IntField
+)
+
+from motorengine.query_builder.field_list import QueryFieldList
+from tests import AsyncTestCase
+
+
+class Name(Document):
+    last = StringField(db_field='last_name')
+    first = StringField()
+
+
+class User(Document):
+    name = EmbeddedDocumentField(embedded_document_type=Name)
+    email = StringField(db_field='email_address')
+    numbers = ListField(base_field=IntField())
+
+
+class TestQueryFieldList(AsyncTestCase):
+    def setUp(self):
+        super(TestQueryFieldList, self).setUp()
+
+    def test_gets_proper_type(self):
+        query1 = QueryFieldList()
+        query2 = QueryFieldList()
+
+        expect(query1).to_be_instance_of(QueryFieldList)
+
+        query = query1 + query2
+
+        expect(query).to_be_instance_of(QueryFieldList)
+
+    def test_default_query_field_list(self):
+        query = QueryFieldList()
+
+        expect(query).not_to_be_null()
+        expect(query.value).to_equal(QueryFieldList.ONLY)
+        expect(query.__nonzero__()).not_to_be_true()
+        expect(query.__bool__()).not_to_be_true()
+        expect(bool(query)).not_to_be_true()
+
+    def test_only_query_field_list(self):
+        query = QueryFieldList(['name', 'email'], value=QueryFieldList.ONLY)
+
+        expect(bool(query)).to_be_true()
+        expect(query.as_dict()).to_be_like({
+            'name': 1, 'email': 1
+        })
+        expect(query.to_query(User)).to_be_like({
+            'name': 1, 'email_address': 1
+        })
+
+        query.reset()
+        expect(query.as_dict()).to_be_like({})
+
+    def test_exclude_query_field_list(self):
+        query = QueryFieldList(
+            fields=['name.last', 'email'],
+            value=QueryFieldList.EXCLUDE
+        )
+
+        expect(bool(query)).to_be_true()
+        expect(query.as_dict()).to_be_like({
+            'name.last': 0, 'email': 0
+        })
+        expect(query.to_query(User)).to_be_like({
+            'name.last_name': 0, 'email_address': 0
+        })
+
+        query.reset()
+        expect(query.as_dict()).to_be_like({})
+
+    def test_union_of_queries_when_only_or_exclude_called(self):
+        query1 = QueryFieldList(
+            fields=['name.last', 'email'],
+            value=QueryFieldList.ONLY,
+            _only_called=True
+        )
+        query2 = QueryFieldList(
+            fields=['name.first'],
+            value=QueryFieldList.ONLY,
+            _only_called=True
+        )
+        query3 = QueryFieldList(
+            fields=['email'],
+            value=QueryFieldList.EXCLUDE
+        )
+        query = query1 + query2
+
+        expect(query.as_dict()).to_be_like({
+            'name.last': 1, 'email': 1, 'name.first': 1
+        })
+
+        query = query + query3
+
+        expect(query.as_dict()).to_be_like({
+            'name.last': 1, 'name.first': 1
+        })
+
+        # try again exclude 'email' that is not in the fields now
+        query = query + QueryFieldList(['email'], value=QueryFieldList.EXCLUDE)
+
+        expect(query.as_dict()).to_be_like({
+            'name.last': 1, 'name.first': 1
+        })
+
+        # the same but exclude first now
+        query = QueryFieldList(['email'], value=QueryFieldList.EXCLUDE) + query
+
+        expect(query.as_dict()).to_be_like({
+            'name.last': 1, 'name.first': 1
+        })
+
+        # exclude first field present in fields
+        query = (
+            QueryFieldList(['name.last'], value=QueryFieldList.EXCLUDE) + query
+        )
+
+        expect(query.as_dict()).to_be_like({
+            'name.first': 1
+        })
+
+        # exclude works only with full names not with prefixes
+        query = (
+            QueryFieldList(['name'], value=QueryFieldList.EXCLUDE) + query
+        )
+
+        expect(query.as_dict()).to_be_like({
+            'name.first': 1
+        })
+
+    def test_union_of_excludes(self):
+        query = (
+            QueryFieldList(['name'], value=QueryFieldList.EXCLUDE) +
+            QueryFieldList(['email', 'numbers'], value=QueryFieldList.EXCLUDE)
+        )
+
+        expect(query.as_dict()).to_be_like({
+            'name': 0, 'email': 0, 'numbers': 0
+        })
+
+    def test_always_include(self):
+        query = QueryFieldList(always_include=['email'])
+        query += QueryFieldList(
+            ['name'], value=QueryFieldList.ONLY, _only_called=True
+        )
+
+        expect(query.as_dict()).to_be_like({'name': 1, 'email': 1})
+
+        query = QueryFieldList(
+            always_include=['email', 'name'], value=QueryFieldList.EXCLUDE
+        )
+        query += QueryFieldList(['email'], value=QueryFieldList.EXCLUDE)
+
+        expect(query.as_dict()).to_be_like({})
+
+    def test_only_query_field_list_and_exclude_id(self):
+        query = QueryFieldList(
+            ['name'], value=QueryFieldList.ONLY, _only_called=True
+        ) + QueryFieldList(['_id'], value=QueryFieldList.EXCLUDE)
+
+        expect(query.as_dict()).to_be_like({
+            '_id': 0, 'name': 1
+        })
+
+    def test_slice_query_field_list(self):
+        query = QueryFieldList(
+            ['numbers'], value={'$slice': 10}, _only_called=False
+        )
+
+        expect(query.as_dict()).to_be_like({
+            'numbers': {'$slice': 10}
+        })
+
+    def test_slice_and_always_include(self):
+        query = (
+            QueryFieldList(['numbers'], always_include=['numbers']) +
+            QueryFieldList(
+                ['numbers'], value={'$slice': 10}, _only_called=False
+            )
+        )
+
+        expect(query.as_dict()).to_be_like({
+            'numbers': {'$slice': 10}
+        })
+
+    def test_slice_with_only_and_exclude(self):
+        query = (
+            QueryFieldList() +
+            QueryFieldList(
+                ['numbers'], value={'$slice': 10}, _only_called=False
+            ) + QueryFieldList(['numbers'], value=QueryFieldList.EXCLUDE)
+        )
+
+        expect(query.as_dict()).to_be_like({})
+
+        # slice is assumed to act like only
+        query = (
+            QueryFieldList() +
+            QueryFieldList(
+                ['numbers'], value={'$slice': 10}, _only_called=False
+            ) + QueryFieldList(
+                ['name'], value=QueryFieldList.ONLY, _only_called=True
+            )
+        )
+
+        expect(query.as_dict()).to_be_like({
+            'name': 1, 'numbers': {'$slice': 10}
+        })
+
+        query = (
+            QueryFieldList() +
+            QueryFieldList(
+                ['numbers'], value={'$slice': 10}, _only_called=False
+            ) + QueryFieldList(
+                ['name'], value={'$slice': 13}, _only_called=False
+            )
+        )
+
+        expect(query.as_dict()).to_be_like({
+            'numbers': {'$slice': 10}, 'name': {'$slice': 13}
+        })
+
+    def test_not_only_called_projection(self):
+        query = (
+            QueryFieldList() +
+            QueryFieldList(
+                ['name'], value=QueryFieldList.ONLY, _only_called=False
+            )
+        )
+
+        expect(query.as_dict()).to_be_like({'name': 1})
+
+    def test_wrong_value(self):
+        query = (
+            QueryFieldList(
+                ['name'], value=QueryFieldList.ONLY, _only_called=False
+            ) +
+            QueryFieldList(
+                ['name'], value='Wrong', _only_called=False
+            )
+        )
+
+        expect(query.as_dict()).to_be_like({'name': 1})

--- a/tests/test_query_projection.py
+++ b/tests/test_query_projection.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+from preggy import expect
+from tornado.testing import gen_test
+
+from motorengine import (
+    Document, StringField, BooleanField, ListField, IntField,
+    URLField, DateTimeField, EmbeddedDocumentField,
+    ReferenceField
+)
+from motorengine.query_builder.field_list import QueryFieldList
+from motorengine.errors import (
+    LoadReferencesRequiredError, PartlyLoadedDocumentError
+)
+from tests import AsyncTestCase
+
+
+class EmbeddedDocument2(Document):
+    test = StringField(db_field="else", required=False)
+
+
+class EmbeddedDocument(Document):
+    test = StringField(db_field="other", required=True)
+    embedded2 = EmbeddedDocumentField(EmbeddedDocument2)
+
+
+class Category(Document):
+    __collection__ = 'categories'
+
+    name = StringField(required=True)
+    descr = StringField(required=True)
+
+
+class Comment(Document):
+    title = StringField(required=True)
+    text = StringField(required=True)
+
+
+class Post(Document):
+    __collection__ = 'posts'
+
+    title = StringField(required=True)
+    text = StringField(required=True, db_field='content')
+    category = ReferenceField(reference_document_type=Category)
+    comments = ListField(EmbeddedDocumentField(embedded_document_type=Comment))
+
+
+class User(Document):
+    __collection__ = 'users'
+
+    email = StringField(required=True)
+    first_name = StringField(
+        db_field="whatever", max_length=50, default=lambda: "Bernardo"
+    )
+    last_name = StringField(max_length=50, default="Heynemann")
+    is_admin = BooleanField(default=True)
+    website = URLField(default="http://google.com/")
+    updated_at = DateTimeField(
+        required=True, auto_now_on_insert=True, auto_now_on_update=True
+    )
+    embedded = EmbeddedDocumentField(
+        EmbeddedDocument, db_field="embedded_document"
+    )
+    nullable = EmbeddedDocumentField(
+        EmbeddedDocument, db_field="nullable_embedded_document"
+    )
+    numbers = ListField(IntField())
+
+    posts = ListField(ReferenceField(reference_document_type=Post))
+
+    def __repr__(self):
+        return "%s %s <%s>" % (self.first_name, self.last_name, self.email)
+
+
+class TestQueryProjection(AsyncTestCase):
+
+    def setUp(self):
+        super(TestQueryProjection, self).setUp()
+        self.drop_coll(User.__collection__)
+        self.drop_coll(Post.__collection__)
+        self.drop_coll(Category.__collection__)
+        self.create_test_objects()
+
+    def create_test_objects(self):
+        User.objects.create(
+            email="heynemann@gmail.com",
+            first_name="Bernardo",
+            last_name="Heynemann",
+            embedded=EmbeddedDocument(test="test"),
+            nullable=None,
+            numbers=[1, 2, 3],
+            callback=self.stop
+        )
+        self.user = self.wait()
+
+        User.objects.create(
+            email="heynemann@gmail.com",
+            first_name="Someone",
+            last_name="Else",
+            embedded=EmbeddedDocument(
+                test="test2",
+                embedded2=EmbeddedDocument2(test="test22")
+            ),
+            nullable=EmbeddedDocument(test="test2"),
+            numbers=[4, 5, 6],
+            callback=self.stop
+        )
+        self.user2 = self.wait()
+
+        User.objects.create(
+            email="heynemann@gmail.com",
+            first_name="Tom",
+            last_name="Doe",
+            embedded=EmbeddedDocument(test="test3"),
+            nullable=EmbeddedDocument(test="test3"),
+            numbers=[7, 8, 9],
+            callback=self.stop
+        )
+        self.user3 = self.wait()
+
+        Category.objects.create(
+            name='category1', descr='category1 description',
+            callback=self.stop
+        )
+        cat1 = self.wait()
+
+        Post.objects.create(
+            title="post1 title",
+            text="post1 text",
+            category=cat1,
+            comments=[
+                Comment(title='comment1', text='comment1 text'),
+                Comment(title='comment2', text='comment2 text'),
+                Comment(title='comment3', text='comment3 text'),
+            ],
+            callback=self.stop
+        )
+        post1 = self.wait()
+
+        self.user.posts.append(post1)
+        self.user.save(callback=self.stop)
+        self.wait()
+
+    def test_can_project_with_only(self):
+        User.objects.filter(last_name="Else")\
+            .only(User.first_name).find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users).to_length(1)
+        expect(users[0].first_name).to_equal("Someone")
+        expect(users[0].last_name).to_equal("Heynemann")  # defaul value
+        expect(users[0].email).to_be_null()
+
+        User.objects.filter(last_name="Else")\
+            .only('first_name').find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users).to_length(1)
+        expect(users[0].first_name).to_equal("Someone")
+        expect(users[0].last_name).to_equal("Heynemann")  # defaul value
+        expect(users[0].email).to_be_null()
+
+    def test_can_project_with_onlies_chain(self):
+        User.objects.only("first_name", "embedded.test").only('last_name')\
+            .get(first_name="Someone", callback=self.stop)
+        user = self.wait()
+
+        expect(user).not_to_be_null()
+        expect(user._id).not_to_be_null()  # _id is still present
+        expect(user.email).to_be_null()
+        expect(user.first_name).to_equal("Someone")
+        expect(user.last_name).to_equal("Else")
+        expect(user.embedded.test).to_equal("test2")
+
+    def test_can_project_with_exclude(self):
+        User.objects.exclude("first_name")\
+            .get(first_name="Someone", callback=self.stop)
+        user = self.wait()
+
+        expect(user).not_to_be_null()
+        expect(user._id).not_to_be_null()
+        expect(user.email).to_equal('heynemann@gmail.com')
+        expect(user.first_name).to_equal("Bernardo")  # default value
+        expect(user.last_name).to_equal("Else")
+        expect(user.embedded.test).to_equal("test2")
+
+        User.objects.exclude(User.first_name)\
+            .get(first_name="Someone", callback=self.stop)
+        user = self.wait()
+
+        expect(user).not_to_be_null()
+        expect(user._id).not_to_be_null()
+        expect(user.email).to_equal('heynemann@gmail.com')
+        expect(user.first_name).to_equal("Bernardo")  # default value
+        expect(user.last_name).to_equal("Else")
+        expect(user.embedded.test).to_equal("test2")
+
+    def test_can_project_with_excludes_chain(self):
+        User.objects.filter(last_name="Else").exclude('_id')\
+            .exclude(User.email).find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users).to_length(1)
+        expect(users[0]._id).to_be_null()
+        expect(users[0].first_name).to_equal("Someone")
+        expect(users[0].last_name).to_equal("Else")
+        expect(users[0].email).to_be_null()
+        expect(users[0].embedded.test).to_equal("test2")
+
+    def test_can_combine_only_and_exclude(self):
+        User.objects.only('first_name').exclude('_id')\
+            .get(last_name="Else", callback=self.stop)
+        user = self.wait()
+
+        expect(user).not_to_be_null()
+        expect(user._id).to_be_null()
+        expect(user.first_name).to_equal("Someone")
+        expect(user.email).to_be_null()
+        expect(user.numbers).to_equal([])
+        expect(user.last_name).to_equal("Heynemann")  # default value
+
+        User.objects.only("email", "numbers").exclude('numbers')\
+            .find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users[0].email).to_equal("heynemann@gmail.com")
+        expect(users[0].numbers).to_equal([])
+
+        User.objects.exclude('numbers').only("email", "numbers")\
+            .find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users[0].email).to_equal("heynemann@gmail.com")
+        expect(users[0].numbers).to_equal([])
+
+    def test_can_project_embedded_fields(self):
+        User.objects.only('embedded.embedded2.test')\
+            .get(last_name="Else", callback=self.stop)
+        user = self.wait()
+
+        expect(user).not_to_be_null()
+        expect(user._id).not_to_be_null()
+        expect(user.last_name).to_equal("Heynemann")  # default value
+        expect(user.first_name).to_equal("Bernardo")  # default value
+        expect(user.embedded.embedded2.test).to_equal('test22')
+        expect(user.embedded.test).to_be_null()
+
+        User.objects.exclude('embedded.test').exclude('email')\
+            .get(last_name="Else", callback=self.stop)
+        user = self.wait()
+
+        expect(user).not_to_be_null()
+        expect(user._id).not_to_be_null()
+        expect(user.last_name).to_equal("Else")
+        expect(user.first_name).to_equal("Someone")
+        expect(user.embedded.test).to_be_null()
+        expect(user.email).to_be_null()
+
+    def test_only_failed_with_wrong_field_name(self):
+        with expect.error_to_happen(
+            ValueError,
+            message="Invalid field 'wrong': Field not found in 'User'."
+        ):
+            User.objects.only('wrong')\
+                .get(last_name="Else", callback=self.stop)
+
+        with expect.error_to_happen(
+            ValueError,
+            message=("Invalid field 'embedded.wrong': "
+                     "Field not found in 'User'.")
+        ):
+            User.objects.only('embedded.wrong')\
+                .get(last_name="Else", callback=self.stop)
+
+    def test_exlude_failed_with_wrong_field_name(self):
+        with expect.error_to_happen(
+            ValueError,
+            message="Invalid field 'wrong': Field not found in 'User'."
+        ):
+            User.objects.exclude('wrong')\
+                .get(last_name="Else", callback=self.stop)
+
+        with expect.error_to_happen(
+            ValueError,
+            message=("Invalid field 'embedded.wrong': "
+                     "Field not found in 'User'.")
+        ):
+            User.objects.exclude('embedded.wrong')\
+                .get(last_name="Else", callback=self.stop)
+
+    def test_fields_failed_with_wrong_field_name(self):
+        with expect.error_to_happen(
+            ValueError,
+            message="Invalid field 'wrong': Field not found in 'User'."
+        ):
+            User.objects.fields(wrong=QueryFieldList.ONLY)\
+                .get(last_name="Else", callback=self.stop)
+
+        with expect.error_to_happen(
+            ValueError,
+            message=("Invalid field 'embedded.wrong': "
+                     "Field not found in 'User'.")
+        ):
+            User.objects.fields(embedded__wrong=QueryFieldList.EXCLUDE)\
+                .get(last_name="Else", callback=self.stop)
+
+        with expect.error_to_happen(
+            ValueError,
+            message=("Invalid field 'embedded.wrong': "
+                     "Field not found in 'User'.")
+        ):
+            User.objects.fields(slice__embedded__wrong=10)\
+                .get(last_name="Else", callback=self.stop)
+
+    def test_can_slice_lists_in_projection(self):
+        User.objects.fields(slice__numbers=2).find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users).to_length(3)
+        expect(users[0].email).to_equal("heynemann@gmail.com")
+        expect(users[0].numbers).to_length(2)
+        expect(users[0].numbers).to_equal([1, 2])
+        expect(users[1].numbers).to_equal([4, 5])
+
+        User.objects.fields(slice__numbers=(1, 2)).find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users).to_length(3)
+        expect(users[0].email).to_equal("heynemann@gmail.com")
+        expect(users[0].numbers).to_length(2)
+        expect(users[0].numbers).to_equal([2, 3])
+        expect(users[1].numbers).to_equal([5, 6])
+
+    def test_can_combine_slice_with_only_and_exlude(self):
+        User.objects.fields(slice__numbers=(1, 1)).only('email')\
+            .find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users[0].email).to_equal("heynemann@gmail.com")
+        expect(users[0].numbers).to_equal([2])
+
+        User.objects.fields(slice__numbers=(1, 1)).exclude('numbers')\
+            .find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users[0].email).to_equal("heynemann@gmail.com")
+        expect(users[0].numbers).to_equal([1, 2, 3])
+
+        User.objects.fields(slice__numbers=(1, 1)).only('_id')\
+            .find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users[0].email).to_be_null()
+        expect(users[0]._id).not_to_be_null()
+        expect(users[0].numbers).to_equal([2])
+
+    def test_can_slice_lists_in_projection_with_negative_skip(self):
+        User.objects.fields(slice__numbers=-2).find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users).to_length(3)
+        expect(users[0].email).to_equal("heynemann@gmail.com")
+        expect(users[0].numbers).to_length(2)
+        expect(users[0].numbers).to_equal([2, 3])
+        expect(users[1].numbers).to_equal([5, 6])
+        expect(users[2].numbers).to_equal([8, 9])
+
+        User.objects.fields(slice__numbers=(-2, 1)).find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users).to_length(3)
+        expect(users[0].email).to_equal("heynemann@gmail.com")
+        expect(users[0].numbers).to_length(1)
+        expect(users[0].numbers).to_equal([2, ])
+        expect(users[1].numbers).to_equal([5, ])
+        expect(users[2].numbers).to_equal([8, ])
+
+    def test_can_project_with_all_fields(self):
+        User.objects.only('last_name').exclude('_id').all_fields()\
+            .get(last_name="Else", callback=self.stop)
+        user = self.wait()
+
+        expect(user).not_to_be_null()
+        expect(user._id).not_to_be_null()
+        expect(user.email).to_equal("heynemann@gmail.com")
+        expect(user.last_name).to_equal('Else')
+        expect(user.first_name).to_equal('Someone')
+        expect(user.numbers).to_equal([4, 5, 6])
+
+    def test_can_project_list_of_embedded_documents(self):
+        Post.objects.exclude('_id').only('comments.text')\
+            .find_all(callback=self.stop)
+        posts = self.wait()
+
+        expect(posts).to_length(1)
+        expect(posts[0]._id).to_be_null()
+        expect(posts[0].title).to_be_null()
+        expect(posts[0].text).to_be_null()
+        expect(posts[0].category).to_be_null()
+        expect(posts[0].comments).to_length(3)
+        expect(posts[0].comments[0].text).to_equal('comment1 text')
+        expect(posts[0].comments[0].title).to_be_null()
+        expect(posts[0].comments[1].text).to_equal('comment2 text')
+        expect(posts[0].comments[1].title).to_be_null()
+        expect(posts[0].comments[2].text).to_equal('comment3 text')
+        expect(posts[0].comments[2].title).to_be_null()
+
+        # the same with fields
+        Post.objects.fields(
+            _id=QueryFieldList.EXCLUDE,
+            comments__text=QueryFieldList.ONLY
+        ).find_all(callback=self.stop)
+        posts = self.wait()
+
+        expect(posts).to_length(1)
+        expect(posts[0]._id).to_be_null()
+        expect(posts[0].title).to_be_null()
+        expect(posts[0].text).to_be_null()
+        expect(posts[0].category).to_be_null()
+        expect(posts[0].comments).to_length(3)
+        expect(posts[0].comments[0].text).to_equal('comment1 text')
+        expect(posts[0].comments[0].title).to_be_null()
+        expect(posts[0].comments[1].text).to_equal('comment2 text')
+        expect(posts[0].comments[1].title).to_be_null()
+        expect(posts[0].comments[2].text).to_equal('comment3 text')
+        expect(posts[0].comments[2].title).to_be_null()
+
+    def test_can_project_reference_field(self):
+        Post.objects.only('title', 'category.name').find_all(
+            lazy=False, callback=self.stop
+        )
+        posts = self.wait()
+
+        expect(posts).to_length(1)
+        expect(posts[0].title).to_equal('post1 title')
+        expect(posts[0].comments).to_length(0)
+        expect(posts[0].text).to_be_null()
+        expect(posts[0].category).to_be_instance_of(Category)
+        expect(posts[0].category.name).to_equal('category1')
+        expect(posts[0].category.descr).to_be_null()
+
+        # the same with load_references
+        Post.objects.only('title', 'category.name').find_all(
+            lazy=True, callback=self.stop
+        )
+        posts = self.wait()
+
+        expect(posts).to_length(1)
+        expect(posts[0].title).to_equal('post1 title')
+        expect(posts[0].comments).to_length(0)
+        expect(posts[0].text).to_be_null()
+
+        with expect.error_to_happen(LoadReferencesRequiredError):
+            cat = posts[0].category
+
+        posts[0].load_references(callback=self.stop)
+        self.wait()
+
+        expect(posts[0].category).to_be_instance_of(Category)
+        expect(posts[0].category.name).to_equal('category1')
+        expect(posts[0].category.descr).to_be_null()
+
+    def test_can_project_list_of_references(self):
+        User.objects.only('first_name', 'posts.title')\
+            .exclude('posts._id').order_by(User.first_name)\
+            .find_all(lazy=False, callback=self.stop)
+        users = self.wait()
+
+        expect(users).to_length(3)
+        expect(users[0].email).to_be_null()
+        expect(users[1].email).to_be_null()
+        expect(users[2].email).to_be_null()
+        expect(users[0].first_name).to_equal("Bernardo")
+        expect(users[1].first_name).to_equal("Someone")
+        expect(users[2].first_name).to_equal("Tom")
+        expect(users[0].last_name).to_equal("Heynemann")
+        expect(users[1].last_name).to_equal("Heynemann")
+        expect(users[2].last_name).to_equal("Heynemann")
+        expect(users[0].posts).to_length(1)
+        expect(users[1].posts).to_length(0)
+        expect(users[2].posts).to_length(0)
+        expect(users[0].posts[0]).to_be_instance_of(Post)
+        expect(users[0].posts[0].title).to_equal('post1 title')
+        expect(users[0].posts[0].text).to_be_null()
+        expect(users[0].posts[0]._id).to_be_null()
+
+    def test_document_is_partly_loaded(self):
+        User.objects.only('first_name').find_all(callback=self.stop)
+        only_users = self.wait()
+
+        expect(only_users[0].is_partly_loaded).to_be_true()
+        expect(only_users[1].is_partly_loaded).to_be_true()
+        expect(only_users[2].is_partly_loaded).to_be_true()
+
+        User.objects.exclude('first_name').find_all(callback=self.stop)
+        exclude_users = self.wait()
+
+        expect(exclude_users[0].is_partly_loaded).to_be_true()
+        expect(exclude_users[1].is_partly_loaded).to_be_true()
+        expect(exclude_users[2].is_partly_loaded).to_be_true()
+
+        User.objects.fields(slice__numbers=2).find_all(callback=self.stop)
+        slice_users = self.wait()
+
+        expect(slice_users[0].is_partly_loaded).to_be_true()
+        expect(slice_users[1].is_partly_loaded).to_be_true()
+        expect(slice_users[2].is_partly_loaded).to_be_true()
+
+    def test_document_is_not_partly_loaded(self):
+        User.objects.find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users[0].is_partly_loaded).not_to_be_true()
+        expect(users[1].is_partly_loaded).not_to_be_true()
+        expect(users[2].is_partly_loaded).not_to_be_true()
+
+        User.objects.only('first_name').exclude('_id')\
+            .all_fields().find_all(callback=self.stop)
+        all_fields_users = self.wait()
+
+        expect(all_fields_users[0].is_partly_loaded).not_to_be_true()
+        expect(all_fields_users[1].is_partly_loaded).not_to_be_true()
+        expect(all_fields_users[2].is_partly_loaded).not_to_be_true()
+
+    def test_document_failed_to_save_partly_loaded_document(self):
+        User.objects.only('first_name')\
+            .get(first_name='Someone', callback=self.stop)
+        user = self.wait()
+
+        with expect.error_to_happen(
+            PartlyLoadedDocumentError,
+            message=(
+                "Partly loaded document User can't be saved. Document should "
+                "be loaded without 'only', 'exclude' or 'fields' "
+                "QuerySet's modifiers"
+            )
+        ):
+            user.save(self.stop)
+
+    def test_queryset_failed_to_save_partly_loaded_document(self):
+        User.objects.only('first_name').filter(first_name='Someone')\
+            .find_all(callback=self.stop)
+        users = self.wait()
+
+        expect(users).to_length(1)
+
+        with expect.error_to_happen(
+            PartlyLoadedDocumentError,
+            message=(
+                "Partly loaded document User can't be saved. Document should "
+                "be loaded without 'only', 'exclude' or 'fields' "
+                "QuerySet's modifiers"
+            )
+        ):
+            User.objects.save(users[0], callback=self.stop)


### PR DESCRIPTION
- bug fix with a default value is not properly set when a db_field is not equal to a name of the field;
- bug fix BoleanField docs error;
- add projection methods `.only()`, `.exclude()`, `.fields()` with list $slice operator, `.all_fields()` to `QuerySet`. So it is possible to specify which fields to load or not to load during a query. Implementation is based on the code of `QueryFieldList` class from the `MongoEngine`.