### PR TITLE
Id handling and cursors

### DIFF
--- a/motorengine/__init__.py
+++ b/motorengine/__init__.py
@@ -19,5 +19,8 @@ try:
     from motorengine.aggregation.base import Aggregation  # NOQA
     from motorengine.query_builder.node import Q, QNot  # NOQA
 
-except ImportError:  # NOQA
-    pass  # likely setup.py trying to import version
+except ImportError as e:  # NOQA
+    # likely setup.py trying to import version
+    import sys
+    import traceback
+    traceback.print_exception(*sys.exc_info())

--- a/motorengine/aggregation/base.py
+++ b/motorengine/aggregation/base.py
@@ -159,7 +159,7 @@ class Aggregation(object):
     @return_future
     def fetch(self, callback=None, alias=None):
         coll = self.queryset.coll(alias)
-        coll.aggregate(self.to_query(), callback=self.handle_aggregation(callback))
+        coll.aggregate(self.to_query(), callback=self.handle_aggregation(callback), cursor=False)
 
     @classmethod
     def avg(cls, field, alias=None):

--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -110,11 +110,11 @@ class BaseDocument(object):
         return True
 
     @return_future
-    def save(self, callback, alias=None):
+    def save(self, callback, alias=None, upsert=False):
         '''
         Creates or updates the current instance of this document.
         '''
-        self.objects.save(self, callback=callback, alias=alias)
+        self.objects.save(self, callback=callback, alias=alias, upsert=upsert)
 
     @return_future
     def delete(self, callback, alias=None):

--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -216,8 +216,8 @@ class BaseDocument(object):
 
         if fields:
             fields = [
-                (field_name, document._fields[field_name])
-                for field_name in fields
+                (field_name, field)
+                for field_name, field in document._fields.items()
                 if field_name in fields
             ]
         else:

--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import six
@@ -73,7 +72,7 @@ class BaseDocument(object):
         for name, value in dic.items():
             field = cls.get_field_by_db_name(name)
             if field:
-                field_values[field.name] = cls._fields[field.name].from_son(value)
+                field_values[field.name] = field.from_son(value)
             else:
                 field_values[name] = value
 

--- a/motorengine/document.py
+++ b/motorengine/document.py
@@ -69,12 +69,14 @@ class BaseDocument(object):
     @classmethod
     def from_son(cls, dic, _is_partly_loaded=False, _reference_loaded_fields=None):
         field_values = {}
+        _object_id = dic.pop('_id', None)
         for name, value in dic.items():
             field = cls.get_field_by_db_name(name)
             if field:
                 field_values[field.name] = field.from_son(value)
             else:
                 field_values[name] = value
+        field_values["_id"] = _object_id
 
         return cls(
             _is_partly_loaded=_is_partly_loaded,

--- a/motorengine/queryset.py
+++ b/motorengine/queryset.py
@@ -106,7 +106,7 @@ class QuerySet(object):
             if field.on_save is not None:
                 setattr(document, field_name, field.on_save(document, creating))
 
-    def save(self, document, callback, alias=None):
+    def save(self, document, callback, alias=None, upsert=False):
         if document.is_partly_loaded:
             msg = (
                 "Partly loaded document {0} can't be saved. Document should "
@@ -118,15 +118,23 @@ class QuerySet(object):
             )
 
         if self.validate_document(document):
-            self.ensure_index(callback=self.indexes_saved_before_save(document, callback, alias=alias), alias=alias)
+            self.ensure_index(
+                callback=self.indexes_saved_before_save(document, callback, alias=alias, upsert=upsert), 
+                alias=alias
+            )
 
-    def indexes_saved_before_save(self, document, callback, alias=None):
+    def indexes_saved_before_save(self, document, callback, alias=None, upsert=False):
         def handle(*args, **kw):
             self.update_field_on_save_values(document, document._id is not None)
             doc = document.to_son()
 
             if document._id is not None:
-                self.coll(alias).update({'_id': document._id}, doc, callback=self.handle_update(document, callback))
+                self.coll(alias).update(
+                    {'_id': document._id}, 
+                    doc, 
+                    callback=self.handle_update(document, callback),
+                    upsert=upsert,
+                )
             else:
                 self.coll(alias).insert(doc, callback=self.handle_save(document, callback))
 

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,9 @@ MotorEngine is a port of the amazing MongoEngine Mapper. Instead of using pymong
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'pymongo==2.7',
+        'pymongo>2.7',
         'tornado',
-        'motor==0.2',
+        'motor>=0.6',
         'six',
         'easydict'
     ],


### PR DESCRIPTION
If the object contains a field called "id", motor engine should not interpret the mongodb field "_id" as a dynamic field. This overrides the "id" field from the object itself in some cases. To be specific if the dictionary of fields from bson converted to a dict contains the objects id field before the "_id" field from mongodb. In that case the mapping is wrong and motor engine overrides the id value from the object with the _id value from mongodb.
Also newer versions of motor return a cursor for aggregations.