### PR TITLE
Updated motorengine for newest version of pymongo, motor and tested with python3.6 and mongodb3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ python:
 
 matrix:
   allow_failures:
-    - python: 3.3
-    - python: pypy
+    - python: "3.3"
+    - python: "pypy"
 
 install:
   - pushd .

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 
 matrix:
   allow_failures:
-    python: pypy
+    python: 3.3, pypy
 
 install:
   - pushd .

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ python:
 
 matrix:
   allow_failures:
-    python: 3.3, pypy
+    - python: 3.3
+    - python: pypy
 
 install:
   - pushd .

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
 
 matrix:
@@ -16,9 +17,9 @@ install:
 
   # installing mongodb
   - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
-  - echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/10gen.list
+  - echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
   - sudo apt-get update
-  - sudo apt-get install -y mongodb-10gen
+  - sudo apt-get install -y mongodb-org
 
   - make setup
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - pushd .
 
   # installing mongodb
-  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
+  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
   - echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
   - sudo apt-get update
   - sudo apt-get install -y mongodb-org

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ mongo_test: kill_mongo_test
 	@mongod --dbpath /tmp/motorengine_test/mongotestdata --logpath /tmp/motorengine_test/mongotestlog --port 4445 --quiet --smallfiles --oplogSize 128 &
 	@mongod --dbpath /tmp/motorengine_test_2/mongotestdata --logpath /tmp/motorengine_test_2/mongotestlog --replSet rs0 --port 27017 --quiet --smallfiles --oplogSize 128 &
 	@mongod --dbpath /tmp/motorengine_test_3/mongotestdata --logpath /tmp/motorengine_test_3/mongotestlog --replSet rs0 --port 27018 --quiet --smallfiles --oplogSize 128 &
-	@sleep 10
+	@sleep 20
 	@mongo --host localhost --port 27017 --eval 'rs.initiate({_id: "rs0", members: [{ _id: 0, host: "localhost:27017" }]});rs.conf();while(!rs.add("localhost:27018")["ok"]){};quit()'
+	@sleep 20
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ motorengine
 
 [![Build Status](https://travis-ci.org/heynemann/motorengine.png?branch=master)](https://travis-ci.org/heynemann/motorengine)
 [![PyPi version](https://img.shields.io/pypi/v/motorengine.svg)](https://pypi.python.org/pypi/motorengine/)
-[![PyPi downloads](https://img.shields.io/pypi/dm/motorengine.svg)](https://pypi.python.org/pypi/motorengine/)
 [![Coverage Status](https://coveralls.io/repos/heynemann/motorengine/badge.png?branch=master)](https://coveralls.io/r/heynemann/motorengine?branch=master)
 
 motorengine is a port of the incredible mongoengine mapper, using Motor for asynchronous access to mongo.

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,6 +1,6 @@
 setuptools==1.1
 sphinx
-pymongo==2.5
+pymongo==3.6
 tornado
 motor
 six

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,10 +8,7 @@ MotorEngine MongoDB Async ORM
 .. image:: https://travis-ci.org/heynemann/motorengine.png
   :target: https://travis-ci.org/heynemann/motorengine
 
-.. image:: https://pypip.in/v/motorengine/badge.png
-  :target: https://crate.io/packages/motorengine/
-
-.. image:: https://pypip.in/d/motorengine/badge.png
+.. image:: https://img.shields.io/pypi/v/motorengine.svg
   :target: https://crate.io/packages/motorengine/
 
 .. image:: https://coveralls.io/repos/heynemann/motorengine/badge.png?branch=master

--- a/motorengine/aggregation/base.py
+++ b/motorengine/aggregation/base.py
@@ -145,7 +145,7 @@ class Aggregation(object):
                 raise RuntimeError('Aggregation failed due to: %s' % str(arguments[1]))
 
             results = []
-            for item in arguments[0]['result']:
+            for item in arguments[0]:
                 #if '_id' in item and isinstance(item['_id'], ObjectId):
                     #results.append(self.get_instance(item))
                 #else:
@@ -159,7 +159,7 @@ class Aggregation(object):
     @return_future
     def fetch(self, callback=None, alias=None):
         coll = self.queryset.coll(alias)
-        coll.aggregate(self.to_query(), callback=self.handle_aggregation(callback))
+        coll.aggregate(self.to_query()).to_list(None, callback=self.handle_aggregation(callback))
 
     @classmethod
     def avg(cls, field, alias=None):

--- a/motorengine/connection.py
+++ b/motorengine/connection.py
@@ -11,7 +11,7 @@ except ImportError:
     pass
 
 try:
-    from motor import MotorClient, MotorReplicaSetClient
+    from motor import MotorClient
 except ImportError:
     pass
 
@@ -69,9 +69,6 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, db=None):
 
         connection_class = MotorClient
         if 'replicaSet' in conn_settings:
-            connection_class = MotorReplicaSetClient
-            conn_settings['hosts_or_uri'] = conn_settings.pop('host', None)
-
             # Discard port since it can't be used on MongoReplicaSetClient
             conn_settings.pop('port', None)
 

--- a/motorengine/connection.py
+++ b/motorengine/connection.py
@@ -53,7 +53,7 @@ def disconnect(alias=DEFAULT_CONNECTION_NAME):
     global _default_dbs
 
     if alias in _connections:
-        get_connection(alias=alias).disconnect()
+        _connections[alias].close()
         del _connections[alias]
         del _connection_settings[alias]
         del _default_dbs[alias]

--- a/motorengine/database.py
+++ b/motorengine/database.py
@@ -11,7 +11,7 @@ class Database(object):
         self.connection.admin.command('ping', callback=callback)
 
     def disconnect(self):
-        return self.connection.disconnect()
+        return self.connection.close()
 
     def __getattribute__(self, name):
         if name in ['ping', 'connection', 'database', 'disconnect']:

--- a/motorengine/fields/datetime_field.py
+++ b/motorengine/fields/datetime_field.py
@@ -24,19 +24,22 @@ class DateTimeField(BaseField):
 
     * `auto_now_on_insert` - When an instance is created sets the field to datetime.now()
     * `auto_now_on_update` - Whenever the instance is saved the field value gets updated to datetime.now()
+    * `tz` - Defines the timezone used for auto_now_on_insert and auto_now_on_update. To interpret all times as UTC
+             use tz=datetime.timezone.utc (Defaults: to None)
     '''
 
-    def __init__(self, auto_now_on_insert=False, auto_now_on_update=False, *args, **kw):
+    def __init__(self, auto_now_on_insert=False, auto_now_on_update=False, tz=None, *args, **kw):
         super(DateTimeField, self).__init__(*args, **kw)
         self.auto_now_on_insert = auto_now_on_insert
         self.auto_now_on_update = auto_now_on_update
+        self.tz = tz
 
     def get_value(self, value):
         if self.auto_now_on_insert and value is None:
-            return datetime.now()
+            return datetime.now(tz=self.tz)
 
         if self.auto_now_on_update:
-            return datetime.now()
+            return datetime.now(tz=self.tz)
 
         return value
 

--- a/motorengine/fields/datetime_field.py
+++ b/motorengine/fields/datetime_field.py
@@ -24,8 +24,9 @@ class DateTimeField(BaseField):
 
     * `auto_now_on_insert` - When an instance is created sets the field to datetime.now()
     * `auto_now_on_update` - Whenever the instance is saved the field value gets updated to datetime.now()
-    * `tz` - Defines the timezone used for auto_now_on_insert and auto_now_on_update. To interpret all times as UTC
-             use tz=datetime.timezone.utc (Defaults: to None)
+    * `tz` - Defines the timezone used for auto_now_on_insert and auto_now_on_update and should be enforced on all
+             values of this datetime field. To interpret all times as UTC use tz=datetime.timezone.utc
+             (Defaults: to None, which means waht you put in comes out again)
     '''
 
     def __init__(self, auto_now_on_insert=False, auto_now_on_update=False, tz=None, *args, **kw):
@@ -44,16 +45,31 @@ class DateTimeField(BaseField):
         return value
 
     def to_son(self, value):
-        if isinstance(value, six.string_types):
-            return datetime.strptime(value, FORMAT)
+        if value is None:
+            return None
 
-        return value
+        if isinstance(value, six.string_types):
+            value = datetime.strptime(value, FORMAT)
+
+        return self.ensure_timezone(value)
 
     def from_son(self, value):
-        if value is None or isinstance(value, datetime):
-            return value
+        if value is None:
+            return None
 
-        return datetime.strptime(value, FORMAT)
+        if isinstance(value, six.string_types):
+            value = datetime.strptime(value, FORMAT)
+
+        return self.ensure_timezone(value)
 
     def validate(self, value):
         return value is None or isinstance(value, datetime)
+
+    def ensure_timezone(self, value):
+        if value.tzinfo is None and self.tz is not None:
+            return value.replace(tzinfo=self.tz)
+
+        if value.tzinfo is not None and self.tz != value.tzinfo:
+            return value.astimezone(self.tz)
+
+        return value

--- a/motorengine/fields/list_field.py
+++ b/motorengine/fields/list_field.py
@@ -71,4 +71,4 @@ class ListField(BaseField):
         if hasattr(self._base_field, 'reference_type'):
             return self._base_field.reference_type
 
-        return self._base_field
+        return type(self._base_field)

--- a/motorengine/fields/uuid_field.py
+++ b/motorengine/fields/uuid_field.py
@@ -29,8 +29,6 @@ class UUIDField(BaseField):
             try:
                 UUID(value)
                 return True
-            except TypeError:
-                pass
             except ValueError:
                 pass
 

--- a/motorengine/queryset.py
+++ b/motorengine/queryset.py
@@ -592,7 +592,7 @@ class QuerySet(object):
             filters = self.get_query_from_filters(filters)
 
         self.coll(alias).find_one(
-            filters, fields=self._loaded_fields.to_query(self.__klass__),
+            filters, projection=self._loaded_fields.to_query(self.__klass__),
             callback=self.handle_get(callback)
         )
 
@@ -618,7 +618,7 @@ class QuerySet(object):
         query_filters = self.get_query_from_filters(self._filters)
 
         return self.coll(alias).find(
-            query_filters, fields=self._loaded_fields.to_query(self.__klass__),
+            query_filters, projection=self._loaded_fields.to_query(self.__klass__),
             **find_arguments
         )
 

--- a/motorengine/queryset.py
+++ b/motorengine/queryset.py
@@ -855,7 +855,6 @@ class QuerySet(object):
                     created_indexes,
                     len(fields_with_index)
                 ),
-                alias=alias
             )
 
         if not fields_with_index:

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,9 @@ MotorEngine is a port of the amazing MongoEngine Mapper. Instead of using pymong
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'pymongo==2.7',
+        'pymongo==3.6',
         'tornado',
-        'motor==0.2',
+        'motor==1.2.1',
         'six',
         'easydict'
     ],

--- a/tests/fields/test_binary_field.py
+++ b/tests/fields/test_binary_field.py
@@ -32,3 +32,8 @@ class TestBinaryField(AsyncTestCase):
         expect(field.is_empty(None)).to_be_true()
         expect(field.is_empty("")).to_be_true()
         expect(field.is_empty("123")).to_be_false()
+
+    def test_from_son(self):
+        field = BinaryField()
+        expect(field.from_son(b"abc")).to_equal(b"abc")
+        expect(field.from_son("abc")).to_equal(b"abc")

--- a/tests/fields/test_binary_field.py
+++ b/tests/fields/test_binary_field.py
@@ -37,3 +37,8 @@ class TestBinaryField(AsyncTestCase):
         field = BinaryField()
         expect(field.from_son(b"abc")).to_equal(b"abc")
         expect(field.from_son("abc")).to_equal(b"abc")
+
+    def test_to_son(self):
+        field = BinaryField()
+        expect(field.to_son(b"abc")).to_equal(b"abc")
+        expect(field.to_son("abc")).to_equal(b"abc")

--- a/tests/fields/test_datetime_field.py
+++ b/tests/fields/test_datetime_field.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from preggy import expect
-from datetime import datetime
+from datetime import datetime, timezone
 
 from motorengine import DateTimeField
 from tests import AsyncTestCase
@@ -44,23 +44,55 @@ class TestDateTimeField(AsyncTestCase):
 
         expect(field.from_son(dt_str)).to_equal(dt)
 
+    def test_from_son_from_string_utc_enforced(self):
+        field = DateTimeField(tz=timezone.utc)
+
+        dt_str = "2010-11-12 13:14:15"
+        dt_utc = datetime(2010, 11, 12, 13, 14, 15, tzinfo=timezone.utc)
+
+        expect(field.from_son(dt_str)).to_equal(dt_utc)
+
     def test_to_son_with_auto_insert(self):
         dt = datetime.now()
         field = DateTimeField(auto_now_on_insert=True)
 
         expect(field.to_son(field.get_value(None))).to_be_greater_or_equal_to(dt)
+        expect(field.get_value(None).tzinfo).to_equal(None)
+
+    def test_to_son_with_auto_insert_utc(self):
+        dt = datetime.now(timezone.utc)
+        field = DateTimeField(auto_now_on_insert=True, tz=timezone.utc)
+
+        expect(field.to_son(field.get_value(None))).to_be_greater_or_equal_to(dt)
+        expect(field.get_value(None).tzinfo).to_equal(timezone.utc)
 
     def test_to_son_with_auto_insert_and_given_value(self):
         field = DateTimeField(auto_now_on_insert=True)
         dt = datetime(2010, 11, 12, 13, 14, 15)
         expect(field.to_son(field.get_value(dt))).to_equal(dt)
+        expect(field.get_value(None).tzinfo).to_equal(None)
+
+    def test_to_son_with_auto_insert_and_given_value_utc(self):
+        field = DateTimeField(auto_now_on_insert=True, tz=timezone.utc)
+        dt = datetime(2010, 11, 12, 13, 14, 15)
+        dt_utc = dt.replace(tzinfo=timezone.utc)
+        expect(field.to_son(field.get_value(dt))).to_equal(dt_utc)
 
     def test_to_son_with_auto_update(self):
         dt = datetime(2010, 11, 12, 13, 14, 15)
         now = datetime.now()
         field = DateTimeField(auto_now_on_update=True)
+        expect(field.get_value(None).tzinfo).to_equal(None)
 
         expect(field.to_son(field.get_value(dt))).to_be_greater_or_equal_to(now)
+
+    def test_to_son_with_auto_update_utc(self):
+        dt = datetime(2010, 11, 12, 13, 14, 15, tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        field = DateTimeField(auto_now_on_update=True, tz=timezone.utc)
+
+        expect(field.to_son(field.get_value(dt))).to_be_greater_or_equal_to(now)
+        expect(field.get_value(None).tzinfo).to_equal(timezone.utc)
 
     def test_validate(self):
         dt = datetime(2010, 11, 12, 13, 14, 15)

--- a/tests/fields/test_datetime_field.py
+++ b/tests/fields/test_datetime_field.py
@@ -50,6 +50,11 @@ class TestDateTimeField(AsyncTestCase):
 
         expect(field.to_son(field.get_value(None))).to_be_greater_or_equal_to(dt)
 
+    def test_to_son_with_auto_insert_and_given_value(self):
+        field = DateTimeField(auto_now_on_insert=True)
+        dt = datetime(2010, 11, 12, 13, 14, 15)
+        expect(field.to_son(field.get_value(dt))).to_equal(dt)
+
     def test_to_son_with_auto_update(self):
         dt = datetime(2010, 11, 12, 13, 14, 15)
         now = datetime.now()

--- a/tests/fields/test_datetime_field.py
+++ b/tests/fields/test_datetime_field.py
@@ -2,10 +2,25 @@
 # -*- coding: utf-8 -*-
 
 from preggy import expect
-from datetime import datetime, timezone
+from datetime import datetime, tzinfo, timedelta
 
 from motorengine import DateTimeField
 from tests import AsyncTestCase
+
+
+class UTC(tzinfo):
+    """UTC"""
+
+    def utcoffset(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return timedelta(0)
+
+utc = UTC()
 
 
 class TestDateTimeField(AsyncTestCase):
@@ -45,10 +60,10 @@ class TestDateTimeField(AsyncTestCase):
         expect(field.from_son(dt_str)).to_equal(dt)
 
     def test_from_son_from_string_utc_enforced(self):
-        field = DateTimeField(tz=timezone.utc)
+        field = DateTimeField(tz=utc)
 
         dt_str = "2010-11-12 13:14:15"
-        dt_utc = datetime(2010, 11, 12, 13, 14, 15, tzinfo=timezone.utc)
+        dt_utc = datetime(2010, 11, 12, 13, 14, 15, tzinfo=utc)
 
         expect(field.from_son(dt_str)).to_equal(dt_utc)
 
@@ -60,11 +75,11 @@ class TestDateTimeField(AsyncTestCase):
         expect(field.get_value(None).tzinfo).to_equal(None)
 
     def test_to_son_with_auto_insert_utc(self):
-        dt = datetime.now(timezone.utc)
-        field = DateTimeField(auto_now_on_insert=True, tz=timezone.utc)
+        dt = datetime.now(utc)
+        field = DateTimeField(auto_now_on_insert=True, tz=utc)
 
         expect(field.to_son(field.get_value(None))).to_be_greater_or_equal_to(dt)
-        expect(field.get_value(None).tzinfo).to_equal(timezone.utc)
+        expect(field.get_value(None).tzinfo).to_equal(utc)
 
     def test_to_son_with_auto_insert_and_given_value(self):
         field = DateTimeField(auto_now_on_insert=True)
@@ -73,9 +88,9 @@ class TestDateTimeField(AsyncTestCase):
         expect(field.get_value(None).tzinfo).to_equal(None)
 
     def test_to_son_with_auto_insert_and_given_value_utc(self):
-        field = DateTimeField(auto_now_on_insert=True, tz=timezone.utc)
+        field = DateTimeField(auto_now_on_insert=True, tz=utc)
         dt = datetime(2010, 11, 12, 13, 14, 15)
-        dt_utc = dt.replace(tzinfo=timezone.utc)
+        dt_utc = dt.replace(tzinfo=utc)
         expect(field.to_son(field.get_value(dt))).to_equal(dt_utc)
 
     def test_to_son_with_auto_update(self):
@@ -87,12 +102,12 @@ class TestDateTimeField(AsyncTestCase):
         expect(field.to_son(field.get_value(dt))).to_be_greater_or_equal_to(now)
 
     def test_to_son_with_auto_update_utc(self):
-        dt = datetime(2010, 11, 12, 13, 14, 15, tzinfo=timezone.utc)
-        now = datetime.now(timezone.utc)
-        field = DateTimeField(auto_now_on_update=True, tz=timezone.utc)
+        dt = datetime(2010, 11, 12, 13, 14, 15, tzinfo=utc)
+        now = datetime.now(utc)
+        field = DateTimeField(auto_now_on_update=True, tz=utc)
 
         expect(field.to_son(field.get_value(dt))).to_be_greater_or_equal_to(now)
-        expect(field.get_value(None).tzinfo).to_equal(timezone.utc)
+        expect(field.get_value(None).tzinfo).to_equal(utc)
 
     def test_validate(self):
         dt = datetime(2010, 11, 12, 13, 14, 15)

--- a/tests/fields/test_email_field.py
+++ b/tests/fields/test_email_field.py
@@ -17,4 +17,5 @@ class TestEmailField(AsyncTestCase):
         field = EmailField()
 
         expect(field.validate("some non email")).to_be_false()
+        expect(field.validate(None)).to_be_true()
         expect(field.validate("someone.else@gmail.com")).to_be_true()

--- a/tests/fields/test_embedded_document_field.py
+++ b/tests/fields/test_embedded_document_field.py
@@ -40,6 +40,7 @@ class TestEmbeddedDocumentField(AsyncTestCase):
         expect(field.to_son(u)).to_be_like({
             'name': 'test'
         })
+        expect(field.to_son(None)).to_equal(None)
 
     def test_from_son(self):
         field = EmbeddedDocumentField(db_field="test", embedded_document_type=User)
@@ -50,3 +51,11 @@ class TestEmbeddedDocumentField(AsyncTestCase):
 
         expect(user).to_be_instance_of(User)
         expect(user.name).to_equal("test2")
+        expect(field.from_son(None)).to_equal(None)
+
+    def test_validate(self):
+        field = EmbeddedDocumentField(User)
+
+        expect(field.validate(None)).to_be_true()
+        expect(field.validate("String")).to_be_false()
+        expect(field.validate(User())).to_be_true()

--- a/tests/fields/test_float_field.py
+++ b/tests/fields/test_float_field.py
@@ -19,12 +19,14 @@ class TestFloatField(AsyncTestCase):
 
         expect(field.to_son(10.0230)).to_equal(10.023)
         expect(field.to_son("10.56")).to_equal(10.56)
+        expect(field.to_son(None)).to_equal(None)
 
     def test_from_son(self):
         field = FloatField()
 
         expect(field.from_son(10.0230)).to_equal(10.023)
         expect(field.from_son("10.56")).to_equal(10.56)
+        expect(field.from_son(None)).to_equal(None)
 
     def test_validate_enforces_floats(self):
         field = FloatField()

--- a/tests/fields/test_int_field.py
+++ b/tests/fields/test_int_field.py
@@ -21,6 +21,7 @@ class TestIntField(AsyncTestCase):
         expect(field.to_son(10.0)).to_equal(10)
         expect(field.to_son(10.0230)).to_equal(10)
         expect(field.to_son("10")).to_equal(10)
+        expect(field.to_son(None)).to_equal(None)
 
     def test_from_son(self):
         field = IntField()
@@ -29,6 +30,7 @@ class TestIntField(AsyncTestCase):
         expect(field.from_son(10.0)).to_equal(10)
         expect(field.from_son(10.0230)).to_equal(10)
         expect(field.from_son("10")).to_equal(10)
+        expect(field.from_son(None)).to_equal(None)
 
     def test_validate_enforces_integers(self):
         field = IntField()

--- a/tests/fields/test_list_field.py
+++ b/tests/fields/test_list_field.py
@@ -5,7 +5,7 @@ import sys
 
 from preggy import expect
 
-from motorengine import ListField, StringField
+from motorengine import ListField, StringField, Document, ReferenceField, EmbeddedDocumentField
 from tests import AsyncTestCase
 
 
@@ -53,3 +53,17 @@ class TestListField(AsyncTestCase):
     def test_embedded_type(self):
         field = ListField(StringField())
         expect(field.item_type).to_equal(StringField)
+
+    def test_item_reference_type(self):
+        class OtherType(Document):
+            pass
+
+        field = ListField(ReferenceField(OtherType))
+        expect(field.item_type).to_equal(OtherType)
+
+    def test_item_embedded_type(self):
+        class OtherType(Document):
+            pass
+
+        field = ListField(EmbeddedDocumentField(OtherType))
+        expect(field.item_type).to_equal(OtherType)

--- a/tests/fields/test_list_field.py
+++ b/tests/fields/test_list_field.py
@@ -49,3 +49,7 @@ class TestListField(AsyncTestCase):
 
         field = ListField(StringField(), required=True)
         expect(field.validate(None)).to_be_false()
+
+    def test_embedded_type(self):
+        field = ListField(StringField())
+        expect(field.item_type).to_equal(StringField)

--- a/tests/fields/test_list_field.py
+++ b/tests/fields/test_list_field.py
@@ -67,3 +67,10 @@ class TestListField(AsyncTestCase):
 
         field = ListField(EmbeddedDocumentField(OtherType))
         expect(field.item_type).to_equal(OtherType)
+
+    def test_to_query(self):
+        field = ListField(StringField())
+        field.from_son(["1", "2", "3"])
+        expect(field.to_query(["1", "2", "3"])).to_equal({
+            "$all": ["1", "2", "3"]
+        })

--- a/tests/fields/test_list_field.py
+++ b/tests/fields/test_list_field.py
@@ -35,6 +35,7 @@ class TestListField(AsyncTestCase):
         field = ListField(StringField())
 
         expect(field.from_son([])).to_equal([])
+        expect(field.from_son(None)).to_equal([])
         expect(field.from_son(["1", "2", "3"])).to_equal(["1", "2", "3"])
 
     def test_validate_propagates(self):
@@ -74,3 +75,10 @@ class TestListField(AsyncTestCase):
         expect(field.to_query(["1", "2", "3"])).to_equal({
             "$all": ["1", "2", "3"]
         })
+        expect(field.to_query("string")).to_equal("string")
+
+    def test_is_empty(self):
+        field = ListField(StringField())
+        expect(field.is_empty(None)).to_be_true()
+        expect(field.is_empty([])).to_be_true()
+        expect(field.is_empty("some")).to_be_false()

--- a/tests/fields/test_reference_field.py
+++ b/tests/fields/test_reference_field.py
@@ -42,6 +42,8 @@ class TestReferenceField(AsyncTestCase):
 
         result = field.to_son(u)
         expect(str(result)).to_equal(str(u._id))
+        expect(field.to_son(None)).to_equal(None)
+        expect(field.to_son(u._id)).to_equal(u._id)
 
     def test_from_son(self):
         field = ReferenceField(db_field="test", reference_document_type=User)
@@ -51,3 +53,9 @@ class TestReferenceField(AsyncTestCase):
         result = field.from_son(data)
 
         expect(result).to_equal(ObjectId("123456789012123456789012"))
+
+    def test_validate(self):
+        field = ReferenceField(db_field="test", reference_document_type=User)
+        expect(field.validate(None)).to_be_true()
+        expect(field.validate("String")).to_be_false()
+        expect(field.validate(ObjectId("123456789012123456789012"))).to_be_true()

--- a/tests/fields/test_uuid_field.py
+++ b/tests/fields/test_uuid_field.py
@@ -32,7 +32,7 @@ class TestUUIDField(AsyncTestCase):
         expect(field.is_empty("")).to_be_true()
         expect(field.is_empty(None)).to_be_true()
 
-    def to_son(self):
+    def test_to_son(self):
         field = UUIDField()
 
         uuid = uuid4()

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -89,6 +89,21 @@ class TestAggregation(AsyncTestCase):
         expect(result[0].email).to_equal('heynemann@gmail.com')
         expect(result[0].number_of_documents).to_be_like(4950.0)
 
+    def test_can_aggregate_number_of_documents_without_alias(self):
+        User.objects.aggregate.group_by(
+            User.email,
+            Aggregation.avg(User.number_of_documents)
+        ).fetch(
+            callback=self.stop
+        )
+
+        result = self.wait()
+
+        expect(result).not_to_be_null()
+        expect(result).to_length(1)
+        expect(result[0].email).to_equal('heynemann@gmail.com')
+        expect(result[0].number_of_documents).to_be_like(4950.0)
+
     def test_can_aggregate_with_unwind(self):
         User.objects.aggregate.unwind(User.list_items).group_by(
             User.email,

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -143,6 +143,15 @@ class TestAggregation(AsyncTestCase):
         #expect(result).not_to_be_null()
         #expect(result).to_length(4)
 
+    def test_can_match_admins(self):
+        User.objects.aggregate.match(
+            is_admin=1
+        ).fetch(callback=self.stop)
+        results = self.wait()
+
+        expect(results).not_to_be_null()
+        expect(results).to_length(50)
+
     def test_can_average_city_population(self):
         City.objects.aggregate.group_by(
             City.state,

--- a/tests/test_aggregation.py
+++ b/tests/test_aggregation.py
@@ -174,6 +174,28 @@ class TestAggregation(AsyncTestCase):
         for state in results:
             expect(state.avg_pop).to_be_greater_than(2000000)
 
+    def test_can_average_city_population_without_alias(self):
+        City.objects.aggregate.group_by(
+            City.state,
+            City.city,
+            Aggregation.sum(City.pop)
+        ).group_by(
+            City.state,
+            Aggregation.avg("pop")
+        ).fetch(callback=self.stop)
+
+        results = self.wait()
+
+        expect(results).not_to_be_null()
+        expect(results).to_length(4)
+
+        states = [result.state for result in results]
+
+        expect(states).to_be_like(['ny', 'ca', 'wa', 'fl'])
+
+        for state in results:
+            expect(state.pop).to_be_greater_than(2000000)
+
     def test_can_average_city_population_by_raw_query(self):
         City.objects.aggregate.raw([
             {

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -27,12 +27,3 @@ class TestConnect(AsyncTestCase):
         args, kwargs = self.exec_async(db.ping)
         ping_result = args[0]['ok']
         expect(ping_result).to_equal(1.0)
-
-    def test_connect_to_replica_set_with_invalid_replicaset_name(self):
-        try:
-            connect('test', host="localhost:27017,localhost:27018", replicaSet=0, port=27017, io_loop=self.io_loop)
-        except ConnectionError:
-            exc_info = sys.exc_info()[1]
-            expect(str(exc_info)).to_include('the replicaSet keyword parameter is required')
-        else:
-            assert False, "Should not have gotten this far"


### PR DESCRIPTION
Hello, 
I needed the support for mongodb 3.6 but the former version of pymongo wasn't able to handle it. So I started the update train, and updated `pymongo` and motor to the newest version. This lead to some fixes in `motorengine`, which are part of this pull request.

I also added some more tests to increase the coverage.

**UPDATE**
I added a `tz` parameter to the `DateTimeField` to enable non naive `datetime` objects to be set with auto insert and auto update. And also ensuring a certain timezone for all set values onwards. If a `datetime` with a different timezone is set, it will converted to the on initialization defined timezone.

All the single steps are elaborated in the commit messages. 

Thanks for this great package.
Cheers