### PR TITLE
Unexpected behaviour of validate() in BinaryField, DecimalField and UrlField

### DIFF
--- a/motorengine/fields/binary_field.py
+++ b/motorengine/fields/binary_field.py
@@ -26,12 +26,18 @@ class BinaryField(BaseField):
         self.max_bytes = max_bytes
 
     def to_son(self, value):
+        if value is None:
+            return None
+
         if not isinstance(value, (six.binary_type, )):
             return six.b(value)
 
         return value
 
     def from_son(self, value):
+        if value is None:
+            return None
+
         if not isinstance(value, (six.binary_type, )):
             return six.b(value)
 

--- a/motorengine/fields/binary_field.py
+++ b/motorengine/fields/binary_field.py
@@ -38,6 +38,9 @@ class BinaryField(BaseField):
         return value
 
     def validate(self, value):
+        if value is None:
+            return True
+
         if not isinstance(value, (six.binary_type, )):
             return False
 

--- a/motorengine/fields/decimal_field.py
+++ b/motorengine/fields/decimal_field.py
@@ -59,6 +59,9 @@ class DecimalField(BaseField):
         return six.u(str(value.quantize(self.precision, rounding=self.rounding)))
 
     def from_son(self, value):
+        if value is None:
+            return True
+
         value = decimal.Decimal(value)
 
         return value.quantize(self.precision, rounding=self.rounding)

--- a/motorengine/fields/decimal_field.py
+++ b/motorengine/fields/decimal_field.py
@@ -59,14 +59,14 @@ class DecimalField(BaseField):
         return six.u(str(value.quantize(self.precision, rounding=self.rounding)))
 
     def from_son(self, value):
-        if value is None:
-            return True
-
         value = decimal.Decimal(value)
 
         return value.quantize(self.precision, rounding=self.rounding)
 
     def validate(self, value):
+        if value is None:
+            return True
+
         try:
             value = decimal.Decimal(value)
         except:

--- a/motorengine/fields/decimal_field.py
+++ b/motorengine/fields/decimal_field.py
@@ -55,10 +55,16 @@ class DecimalField(BaseField):
         self.rounding = rounding
 
     def to_son(self, value):
+        if value is None:
+            return None
+        
         value = decimal.Decimal(value)
         return six.u(str(value.quantize(self.precision, rounding=self.rounding)))
 
     def from_son(self, value):
+        if value is None:
+            return None
+
         value = decimal.Decimal(value)
 
         return value.quantize(self.precision, rounding=self.rounding)

--- a/motorengine/fields/url_field.py
+++ b/motorengine/fields/url_field.py
@@ -34,6 +34,9 @@ class URLField(BaseField):
     )
 
     def validate(self, value):
+        if value is None:
+            return True
+
         is_url = URLField.URL_REGEX.match(value)
 
         return is_url


### PR DESCRIPTION
Hello,

I recently started using MotorEngine and quickly came up with a strange behaviour of the validate function in certain Fields. If required is `False` then validate should allow `None` as a valid value.

I added a fix for BinaryField, DecimalField and UrlField and would be glad if this fix could be merged back into the original project.

Best regards,
Steven