### PR TITLE
update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ MotorEngine is a port of the amazing MongoEngine Mapper. Instead of using pymong
         'six',
         'easydict'
     ],
-    use_2to3=True,
     extras_require={
         'tests': tests_require,
     },


### PR DESCRIPTION
remove use_2to3 as python 2 is not developing anymore
and will raise error while installing with setuptools 58.3.0